### PR TITLE
Refactor 2

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -93,7 +93,7 @@ export class App extends Component {
     const { selectedColor, selectedImg } = this.state;
 
     return (
-      <div className="App">
+      <div className="App" onContextMenu={(e)=> e.preventDefault()}>
         <Route exact path="/" render={()=>
           <Splash
           selectedColor={selectedColor}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -7,7 +7,6 @@ import { Gallery } from '../Gallery/Gallery';
 import { Photo } from '../Photo/Photo';
 import { About } from '../About/About';
 import { Splash } from '../Splash/Splash';
-import { Loader } from '../Loader/Loader';
 
 import { images } from '../../data';
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -18,7 +18,7 @@ export class App extends Component {
       selectedImg: {}
     };
   }
-
+  
   componentDidMount = () => {
     document.title = 'MacRae Photo';
   };

--- a/src/components/Contact/Contact.js
+++ b/src/components/Contact/Contact.js
@@ -47,6 +47,7 @@ export class Contact extends Component {
       try {
         const response = await postMessage(email, message);
         this.clearState();
+        return response;
       } catch(error) {
           console.log(error);
           this.setState({error: 'There was a problem sending your message - Please try again.'});

--- a/src/components/Contact/Contact.js
+++ b/src/components/Contact/Contact.js
@@ -77,13 +77,13 @@ export class Contact extends Component {
             <div className="contact-wrapper">
               <div className="email-input-wrapper">
                 <div className="email-section">
-                  <label for="email" className="input-label">Email:</label>
-                  <input className="contact-input" id="email" value={this.state.email} onChange={e => this.handleChange(e)} autocomplete="off"/>
+                  <label htmlFor="email" className="input-label">Email:</label>
+                  <input className="contact-input" id="email" value={this.state.email} onChange={e => this.handleChange(e)} autoComplete="off"/>
                 </div>
                 <Link to="/" className="back-btn">Back</Link>
               </div>
               <div className="message-input-wrapper">
-                <label for="message" className="input-label">Message:</label>
+                <label htmlFor="message" className="input-label">Message:</label>
                 <textarea className="contact-input" id="message" value={this.state.message} onChange={e => this.handleChange(e)}>
                 </textarea>
               </div>

--- a/src/components/Loader/__snapshots__/Loader.test.js.snap
+++ b/src/components/Loader/__snapshots__/Loader.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Loader Should match the snapshot 1`] = `ShallowWrapper {}`;

--- a/src/components/Popup/Popup.js
+++ b/src/components/Popup/Popup.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 import './Popup.scss';
@@ -9,7 +9,7 @@ export const Popup = (props) => {
   return (
     <div className="Popup">
       <div className="popup-inner">
-        <img src={require('../../images/icons/cancel.svg')} className="exit-btn" onClick={() => closePopup()}/>
+        <img alt="Exit button" src={require('../../images/icons/cancel.svg')} className="exit-btn" onClick={() => closePopup()}/>
         <h5 className="popup-header">Thank you for your message!</h5>
         <span className="popup-desc">Please expect a reply to the provided email in 3-5 business days</span>
         <Link className="popup-back-link" to="/">Back to Home</Link>

--- a/src/components/Popup/__snapshots__/Popup.test.js.snap
+++ b/src/components/Popup/__snapshots__/Popup.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Popup Should match the snapshot 1`] = `ShallowWrapper {}`;


### PR DESCRIPTION
### What does this PR do? 

- Disables the context menu to prevent visitors from saving images.
- Removes and alters several lines that were causing console warnings and errors.
- Removes unneeded lines/minor refactoring.

----------

### How to manually test: 

- `git fetch`
- `git checkout refactor-2`
- `npm test` to ensure all tests are passing. 
- 'npm start', open site in browser, visit all pages and ensure that there are no console errors or warnings. (See note) 

----------

### Tickets: 

- Resolves #24 
- Resolves #37 
- Resolves #45 

----------

### Notes: 

- A warning reading: `Warning: Accessing createClass via the main React package is deprecated...` will still appear. As far as I know this warning is unremovable on my end. 

- I am seeing another warning stating: `DevTools failed to load SourceMap: Could not load content for chrome-extension://mihdfbecejheednfigjpdacgeilhlmnf/react-draggable.js.map: HTTP error: status code 404, net::ERR_UNKNOWN_URL_SCHEME`. I believe this is a bug with the dev tools but I will continue to look into it.  